### PR TITLE
feat: add valgrind testing

### DIFF
--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   valgrind:
-    runs-on: ubuntu
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - name: Install valgrind and development dependencies

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -1,0 +1,35 @@
+name: Valgrind
+
+on:
+  workflow_dispatch:
+  workflow_call:
+  push:
+    branches: [ "*" ]
+  pull_request:
+    types: [ opened, synchronize, ready_for_review ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  valgrind:
+    runs-on: ubuntu
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install valgrind and development dependencies
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y cmake libc6-dev valgrind
+    - name: Build
+      run: |
+        gcc --version
+        mkdir build
+        cd build
+        cmake ..
+        make -j `nproc`
+    - name: Test under valgrind
+      run: |
+        cd build
+        valgrind -q --error-exitcode=99 --leak-check=full ./test
+


### PR DESCRIPTION
This PR contains valgrind.yml that runs test suite under valgrind memcheck.

Description:
When we use `--error-exitcode=<number>`, Valgrind will change the program's exit code to the given number when an error (memory leak) is detected. We also add `--quiet` (or `-q`) to make Valgrind silent, so that it doesn't interfere with the normal `stdout` and `stderr` of the program, except for error output, so that you can compare the program output as usual.

Remember that by default Memcheck regards only definitely lost and possibly lost memory blocks as errors. You can change that by using `--errors-for-leak-kinds=set`. If you are interested in getting an error only for definitely lost blocks, you can use `--errors-for-leak-kinds=definite`. When your test programs always free all memory blocks, including still reachable blocks, you can use `--errors-for-leak-kinds=definite`,possibly,reachable or `--errors-for-leak-kinds=all`. Note that `--errors-for-leak-kinds=set`, which works together with `--error-exitcode=number` and the above mentioned `--show-leak-kinds=set` option, which determines which backtraces to show, are independent. But in general you will want them to be the same, so that you will always get a backtrace for a memory error.

So, a good way to run your tests is `valgrind -q --error-exitcode=99 --leak-check=full ./test`. If you have any local suppressions, you can add `--suppressions=local.supp`. And if you really want all your test cases to be totally free from any kind of memory leak, add `--show-leak-kinds=all --errors-for-leak-kinds=all`.